### PR TITLE
List Ruby and Sass adapters in a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ gem install ruby-cssesc
 
 ```ruby
 require 'ruby-cssesc'
-CSSEsc.escape('I ♥ Ruby')
+CSSEsc.escape('I ♥ Ruby', is_identifier: true)
 ```
 
 In Sass using [sassy-escape](https://github.com/borodean/sassy-escape):
@@ -93,7 +93,7 @@ gem install sassy-escape
 
 ```scss
 body {
-  content: escape('I ♥ Sass');
+  content: escape('I ♥ Sass', $is-identifier: true);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ require(
 );
 ```
 
+In Ruby using [a wrapper gem](https://github.com/borodean/ruby-cssesc):
+
+```bash
+gem install ruby-cssesc
+```
+
+```ruby
+require 'ruby-cssesc'
+CSSEsc.escape('I ♥ Ruby')
+```
+
+In Sass using [sassy-escape](https://github.com/borodean/sassy-escape):
+
+```bash
+gem install sassy-escape
+```
+
+```scss
+body {
+  content: escape('I ♥ Sass');
+}
+```
+
 ## API
 
 ### `cssesc(value, options)`


### PR DESCRIPTION
This is a pull request for issue https://github.com/mathiasbynens/cssesc/issues/6.

I’m not sure on how the text and examples should be structured to fit nicely you documenting style.

@mathiasbynens, could you give me a hint on how can I fix it?