### PR TITLE
Escape single and double quotes within identifiers.

### DIFF
--- a/cssesc.js
+++ b/cssesc.js
@@ -18,8 +18,8 @@ const merge = function(options, defaults) {
 	return result;
 };
 
-const regexAnySingleEscape = /[ -,\./;-@\[-\^`\{-~]/;
-const regexSingleEscape = /[ !#-&\(-,\./;-@\[\]\^`\{-~]/;
+const regexAnySingleEscape = /[ -,\.\/;-@\[-\^`\{-~]/;
+const regexSingleEscape = /[ -,\.\/;-@\[\]\^`\{-~]/;
 const regexAlwaysEscape = /['"\\]/;
 const regexExcessiveSpaces = /(^|\\+)?(\\[A-F0-9]{1,6})\x20(?![a-fA-F0-9\x20])/g;
 

--- a/src/data.js
+++ b/src/data.js
@@ -10,6 +10,6 @@ var set = regenerate().add(
 
 module.exports = {
 	'anySingleEscape': set.toString(),
-	'singleEscapes': set.remove('"', '\'', '\\').toString(),
+	'singleEscapes': set.remove('\\').toString(),
 	'version': JSON.parse(fs.readFileSync('package.json', 'utf8')).version
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -96,6 +96,11 @@ describe('common usage', function() {
 			'more backslashes with `isIdentifier: true`'
 		);
 		assert.equal(
+			cssesc('id"ent\'ifier', { 'isIdentifier': true }),
+			'id\\"ent\\\'ifier',
+			'quotes are escaped with `isIdentifier: true`'
+		);
+		assert.equal(
 			cssesc('a"b\'c\xA9d', { 'wrap': true }),
 			'\'a"b\\\'c\\A9 d\'',
 			'quotes with `wrap: true`'


### PR DESCRIPTION
If a string has quote marks in it and is being escaped as an ident, those quotes should be escaped.