### PR TITLE
Add failing test showing colons are sometimes escaped improperly

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -56,6 +56,11 @@ describe('common usage', () => {
 			'foo:bar (avoid `\\:` for IE < 8 compatibility) with `isIdentifier: true`'
 		);
 		assert.equal(
+			cssesc('hello:there', { 'isIdentifier': true }),
+			'hello\\3A there',
+			'hello:there (avoid `\\:` for IE < 8 compatibility) with `isIdentifier: true`'
+		);
+		assert.equal(
 			cssesc('_foo_bar', { 'isIdentifier': false }),
 			'_foo_bar',
 			'_foo_bar with `isIdentifier: false`'


### PR DESCRIPTION
For some reason escaping `:` characters sometimes comes out as `\3A` instead of `\3A ` (note the missing trailing space.)

Not sure if this matters or not because Chrome seems to handle the CSS fine either way, but it's a bit odd for sure.

Side note, I would love if it was possible to just disable IE < 8 compatibility and use `\:`, I've gotta believe market share for those browsers is effectively zero at this point.