### PR TITLE
Drop special behavior for legacy browsers

### DIFF
--- a/cssesc.js
+++ b/cssesc.js
@@ -1,4 +1,4 @@
-/*! https://mths.be/cssesc v1.0.1 by @mathias */
+/*! https://mths.be/cssesc v2.0.0 by @mathias */
 'use strict';
 
 var object = {};
@@ -16,8 +16,8 @@ var merge = function merge(options, defaults) {
 	return result;
 };
 
-var regexAnySingleEscape = /[ -,\.\/;-@\[-\^`\{-~]/;
-var regexSingleEscape = /[ -,\.\/;-@\[\]\^`\{-~]/;
+var regexAnySingleEscape = /[ -,\.\/:-@\[-\^`\{-~]/;
+var regexSingleEscape = /[ -,\.\/:-@\[\]\^`\{-~]/;
 var regexAlwaysEscape = /['"\\]/;
 var regexExcessiveSpaces = /(^|\\+)?(\\[A-F0-9]{1,6})\x20(?![a-fA-F0-9\x20])/g;
 
@@ -60,13 +60,8 @@ var cssesc = function cssesc(string, options) {
 				} else {
 					value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
 				}
-				// Note: `:` could be escaped as `\:`, but that fails in IE < 8.
-			} else if (/[\t\n\f\r\x0B:]/.test(character)) {
-				if (!isIdentifier && character == ':') {
-					value = character;
-				} else {
-					value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
-				}
+			} else if (/[\t\n\f\r\x0B]/.test(character)) {
+				value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
 			} else if (character == '\\' || !isIdentifier && (character == '"' && quote == character || character == '\'' && quote == character) || isIdentifier && regexSingleEscape.test(character)) {
 				value = '\\' + character;
 			} else {
@@ -77,11 +72,7 @@ var cssesc = function cssesc(string, options) {
 	}
 
 	if (isIdentifier) {
-		if (/^_/.test(output)) {
-			// Prevent IE6 from ignoring the rule altogether (in case this is for an
-			// identifier used as a selector)
-			output = '\\_' + output.slice(1);
-		} else if (/^-[-\d]/.test(output)) {
+		if (/^-[-\d]/.test(output)) {
 			output = '\\-' + output.slice(1);
 		} else if (/\d/.test(firstChar)) {
 			output = '\\3' + firstChar + ' ' + output.slice(1);
@@ -114,6 +105,6 @@ cssesc.options = {
 	'wrap': false
 };
 
-cssesc.version = '1.0.1';
+cssesc.version = '2.0.0';
 
 module.exports = cssesc;

--- a/cssesc.js
+++ b/cssesc.js
@@ -1,4 +1,4 @@
-/*! https://mths.be/cssesc v2.0.0 by @mathias */
+/*! https://mths.be/cssesc v1.0.1 by @mathias */
 'use strict';
 
 var object = {};
@@ -105,6 +105,6 @@ cssesc.options = {
 	'wrap': false
 };
 
-cssesc.version = '2.0.0';
+cssesc.version = '1.0.1';
 
 module.exports = cssesc;

--- a/src/cssesc.js
+++ b/src/cssesc.js
@@ -61,13 +61,8 @@ const cssesc = (string, options) => {
 				} else {
 					value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
 				}
-			// Note: `:` could be escaped as `\:`, but that fails in IE < 8.
-			} else if (/[\t\n\f\r\x0B:]/.test(character)) {
-				if (!isIdentifier && character == ':') {
-					value = character;
-				} else {
-					value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
-				}
+			} else if (/[\t\n\f\r\x0B]/.test(character)) {
+				value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
 			} else if (
 				character == '\\' ||
 				(
@@ -88,11 +83,7 @@ const cssesc = (string, options) => {
 	}
 
 	if (isIdentifier) {
-		if (/^_/.test(output)) {
-			// Prevent IE6 from ignoring the rule altogether (in case this is for an
-			// identifier used as a selector)
-			output = '\\_' + output.slice(1);
-		} else if (/^-[-\d]/.test(output)) {
+		if (/^-[-\d]/.test(output)) {
 			output = '\\-' + output.slice(1);
 		} else if (/\d/.test(firstChar)) {
 			output = '\\3' + firstChar + ' ' + output.slice(1);

--- a/src/data.js
+++ b/src/data.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 // Characters with special meaning in CSS, except for quotes and backslashes
 // (they get a separate regex)
 var set = regenerate().add(
-	' ', '!', '#', '$', '%', '&', '(', ')', '*', '+', ',', '.', '/', ';', '<',
+	' ', '!', '#', '$', '%', '&', '(', ')', '*', '+', ',', '.', '/', ';', '<', ':',
 	'=', '>', '?', '@', '[', ']', '^', '`', '{', '|', '}', '~', '"', '\'', '\\'
 );
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -48,12 +48,12 @@ describe('common usage', () => {
 		assert.equal(
 			cssesc('foo:bar', { 'isIdentifier': false }),
 			'foo:bar',
-			'foo:bar (avoid `\\:` for IE < 8 compatibility) with `isIdentifier: false`'
+			'foo:bar with `isIdentifier: false`'
 		);
 		assert.equal(
 			cssesc('foo:bar', { 'isIdentifier': true }),
-			'foo\\3A bar',
-			'foo:bar (avoid `\\:` for IE < 8 compatibility) with `isIdentifier: true`'
+			'foo\\:bar',
+			'foo:bar with `isIdentifier: true`'
 		);
 		assert.equal(
 			cssesc('_foo_bar', { 'isIdentifier': false }),
@@ -62,8 +62,8 @@ describe('common usage', () => {
 		);
 		assert.equal(
 			cssesc('_foo_bar', { 'isIdentifier': true }),
-			'\\_foo_bar',
-			'_foo_bar (escape leading `_` for IE6 compatibility) with `isIdentifier: true`'
+			'_foo_bar',
+			'_foo_bar with `isIdentifier: true`'
 		);
 		assert.equal(
 			cssesc('a\t\n\v\f\rb'),


### PR DESCRIPTION
This PR removes the special handling of the `:` character in CSS identifiers so that they simply escaped as `\:`, and also removes the special handling of leading `_` characters in identifiers so they are not escaped.

Hopefully I've followed the build process properly, I noticed there were changes in `src/cssesc.js` that hadn't been added to the build in `/cssesc.js` (namely the version number) so those changes were sort of brought in accidentally just by me running the build.